### PR TITLE
Add evaluated cafe choices with feedback and TTS

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { FeedbackChip } from './components';
 import { selectCurrentNode, useGameState } from './game/state';
+import type { PlayerChoice } from './scenes/types';
 
 const CAFE_SCENE_ID = 'cafe';
+
+type ChoiceFeedback = Record<
+  string,
+  {
+    evaluation: PlayerChoice['eval'];
+    message: string;
+  }
+>;
 
 function App() {
   const sceneId = useGameState((state) => state.sceneId);
   const startScene = useGameState((state) => state.startScene);
   const currentNode = useGameState(selectCurrentNode);
+  const goToNode = useGameState((state) => state.goToNode);
+  const reset = useGameState((state) => state.reset);
 
   const hasStarted = Boolean(sceneId);
+  const [feedbackByChoice, setFeedbackByChoice] = useState<ChoiceFeedback>({});
+  const advanceTimeoutRef = useRef<number | null>(null);
+
+  const clearAdvanceTimeout = useCallback(() => {
+    if (typeof window === 'undefined') {
+      advanceTimeoutRef.current = null;
+      return;
+    }
+
+    if (advanceTimeoutRef.current !== null) {
+      window.clearTimeout(advanceTimeoutRef.current);
+      advanceTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearAdvanceTimeout(), [clearAdvanceTimeout]);
+
+  const speak = useCallback((text: string) => {
+    if (!text || typeof window === 'undefined') {
+      return;
+    }
+
+    const synth = window.speechSynthesis;
+    if (!synth) {
+      return;
+    }
+
+    synth.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'he-IL';
+    synth.speak(utterance);
+  }, []);
+
+  useEffect(() => {
+    if (currentNode?.npc.text) {
+      speak(currentNode.npc.text);
+    }
+
+    setFeedbackByChoice({});
+    clearAdvanceTimeout();
+  }, [currentNode?.id, currentNode?.npc.text, clearAdvanceTimeout, speak]);
+
+  const scheduleAdvance = useCallback(
+    (choice: PlayerChoice) => {
+      const proceed = () => {
+        goToNode(choice.nextNodeId, choice.reward ?? 0, choice.wordsLearned ?? []);
+      };
+
+      if (typeof window === 'undefined') {
+        proceed();
+        return;
+      }
+
+      clearAdvanceTimeout();
+      const delay = 800 + Math.random() * 400;
+      const timeoutId = window.setTimeout(() => {
+        proceed();
+        advanceTimeoutRef.current = null;
+      }, delay);
+      advanceTimeoutRef.current = timeoutId;
+    },
+    [clearAdvanceTimeout, goToNode],
+  );
+
+  const handleChoiceClick = useCallback(
+    (choice: PlayerChoice) => {
+      setFeedbackByChoice((prev) => ({
+        ...prev,
+        [choice.id]: { evaluation: choice.eval, message: choice.feedback },
+      }));
+
+      if (choice.eval === 'good') {
+        speak(choice.text);
+      }
+
+      if (choice.eval === 'good' || choice.eval === 'ok') {
+        scheduleAdvance(choice);
+      }
+    },
+    [scheduleAdvance, speak],
+  );
 
   return (
     <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center bg-gradient-to-b from-emerald-50 via-white to-emerald-100 px-6 py-16 text-slate-900">
@@ -38,12 +133,53 @@ function App() {
 
         {hasStarted && currentNode && (
           <section className="rounded-2xl bg-white p-8 shadow-xl">
-            <h2 className="text-xl font-semibold text-emerald-700">
-              {currentNode.npc.speaker}
-            </h2>
-            <p className="mt-4 text-lg leading-relaxed text-slate-700">
-              {currentNode.npc.text}
-            </p>
+            <div className="flex flex-col gap-8">
+              <div>
+                <h2 className="text-xl font-semibold text-emerald-700">
+                  {currentNode.npc.speaker}
+                </h2>
+                <p className="mt-4 text-lg leading-relaxed text-slate-700" dir="rtl" lang="he">
+                  {currentNode.npc.text}
+                </p>
+              </div>
+
+              {currentNode.playerChoices.length > 0 ? (
+                <ul className="flex flex-col gap-4">
+                  {currentNode.playerChoices.map((choice) => {
+                    const feedback = feedbackByChoice[choice.id];
+                    return (
+                      <li key={choice.id} className="flex flex-col items-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleChoiceClick(choice)}
+                          className="w-full rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-right text-lg font-semibold text-emerald-800 shadow-sm transition hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+                          dir="rtl"
+                          lang="he"
+                        >
+                          {choice.text}
+                        </button>
+                        {feedback && (
+                          <FeedbackChip evaluation={feedback.evaluation} message={feedback.message} />
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <div className="flex flex-col items-center gap-4 rounded-xl bg-emerald-50 p-6 text-center">
+                  <p className="text-lg font-semibold text-emerald-700" dir="rtl" lang="he">
+                    כל הכבוד! סיימת את השיחה.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="rounded-full bg-emerald-600 px-5 py-2 text-base font-semibold text-white shadow transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+                  >
+                    התחל מחדש
+                  </button>
+                </div>
+              )}
+            </div>
           </section>
         )}
       </main>

--- a/src/components/FeedbackChip.tsx
+++ b/src/components/FeedbackChip.tsx
@@ -1,0 +1,33 @@
+import type { PlayerChoice } from '../scenes/types';
+
+type FeedbackChipProps = {
+  evaluation: PlayerChoice['eval'];
+  message: string;
+};
+
+const styles: Record<PlayerChoice['eval'], string> = {
+  good: 'bg-emerald-100 text-emerald-800 border border-emerald-200',
+  ok: 'bg-amber-100 text-amber-900 border border-amber-200',
+  wrong: 'bg-rose-100 text-rose-800 border border-rose-200',
+};
+
+const icons: Record<PlayerChoice['eval'], string> = {
+  good: '✨',
+  ok: '👍',
+  wrong: '🤔',
+};
+
+function FeedbackChip({ evaluation, message }: FeedbackChipProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 self-end rounded-full px-3 py-1 text-sm font-medium shadow-sm ${styles[evaluation]}`}
+      dir="rtl"
+      lang="he"
+    >
+      <span aria-hidden="true">{icons[evaluation]}</span>
+      {message}
+    </span>
+  );
+}
+
+export default FeedbackChip;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { default as FeedbackChip } from './FeedbackChip';

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -16,6 +16,7 @@ type GameState = {
   wordsLearned: string[];
   scenes: Record<string, Scene>;
   startScene: (sceneId: string) => void;
+  goToNode: (nextNodeId: string, reward?: number, wordsLearned?: string[]) => void;
   reset: () => void;
 };
 
@@ -39,6 +40,30 @@ export const useGameState = create<GameState>((set) => ({
       wordsLearned: [],
     });
   },
+  goToNode: (nextNodeId, reward = 0, newWords = []) =>
+    set((state) => {
+      if (!state.sceneId) {
+        return state;
+      }
+
+      const scene = state.scenes[state.sceneId];
+      if (!scene?.nodes[nextNodeId]) {
+        console.warn(`Node with id "${nextNodeId}" not found in scene "${state.sceneId}".`);
+        return state;
+      }
+
+      const uniqueWords = new Set(state.wordsLearned);
+      for (const word of newWords) {
+        uniqueWords.add(word);
+      }
+
+      return {
+        ...state,
+        nodeId: nextNodeId,
+        points: state.points + reward,
+        wordsLearned: Array.from(uniqueWords),
+      };
+    }),
   reset: () =>
     set({
       sceneId: null,

--- a/src/scenes/cafe.json
+++ b/src/scenes/cafe.json
@@ -7,8 +7,75 @@
     "greeting": {
       "id": "greeting",
       "npc": {
-        "speaker": "Barista",
+        "speaker": "הבריסטה",
         "text": "ברוך הבא לבית הקפה שלנו! מה תרצה להזמין היום?"
+      },
+      "playerChoices": [
+        {
+          "id": "order-cappuccino",
+          "text": "אני רוצה קפה הפוך, בבקשה.",
+          "nextNodeId": "drink-details",
+          "eval": "good",
+          "feedback": "מעולה! זו הדרך המדויקת לבקש קפה הפוך.",
+          "reward": 2,
+          "wordsLearned": ["קפה הפוך"]
+        },
+        {
+          "id": "order-coffee",
+          "text": "אפשר קפה, תודה.",
+          "nextNodeId": "drink-details",
+          "eval": "ok",
+          "feedback": "סבבה! אפשר לבקש גם יותר ספציפי אם תרצה.",
+          "reward": 1,
+          "wordsLearned": ["קפה"]
+        },
+        {
+          "id": "ask-restroom",
+          "text": "איפה השירותים?",
+          "nextNodeId": "greeting",
+          "eval": "wrong",
+          "feedback": "זה פחות קשור להזמנה. נסה לענות להזמנה."
+        }
+      ]
+    },
+    "drink-details": {
+      "id": "drink-details",
+      "npc": {
+        "speaker": "הבריסטה",
+        "text": "מצוין! תרצה סוכר או חלב מיוחד?"
+      },
+      "playerChoices": [
+        {
+          "id": "details-brown-sugar",
+          "text": "אפשר מעט סוכר חום.",
+          "nextNodeId": "closing",
+          "eval": "good",
+          "feedback": "בחירה מצוינת! כך תבקש סוכר חום.",
+          "reward": 2,
+          "wordsLearned": ["סוכר חום"]
+        },
+        {
+          "id": "details-no-sugar",
+          "text": "בלי סוכר, תודה.",
+          "nextNodeId": "closing",
+          "eval": "ok",
+          "feedback": "אין בעיה! זו תשובה ברורה ומנומסת.",
+          "reward": 1
+        },
+        {
+          "id": "details-small-talk",
+          "text": "איזה יום יפה היום!",
+          "nextNodeId": "drink-details",
+          "eval": "wrong",
+          "feedback": "נחמד, אבל הבריסטה עדיין מחכה לתשובה לגבי הקפה."
+        }
+      ]
+    },
+    "closing": {
+      "id": "closing",
+      "npc": {
+        "speaker": "הבריסטה",
+        "text": "הכל מוכן! שב בנחת ואני אביא את המשקה עוד רגע."
       },
       "playerChoices": []
     }

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -7,6 +7,8 @@ export type PlayerChoice = {
   id: string;
   text: string;
   nextNodeId: string;
+  eval: 'good' | 'ok' | 'wrong';
+  feedback: string;
   reward?: number;
   wordsLearned?: string[];
 };


### PR DESCRIPTION
## Summary
- add evaluation-aware choice handling with inline feedback chips and delayed progression
- hook Hebrew text-to-speech to NPC dialogue and correct responses while aligning dialogue RTL
- expand the café scene with graded choices, follow-up nodes, and updated state helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de77df8cfc833294111c2dc749655c