### PR TITLE
Ensure esbuild binary installs when dependencies are installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "daily-hebrew-adventure",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "node ./scripts/ensure-esbuild-binary.mjs"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/scripts/ensure-esbuild-binary.mjs
+++ b/scripts/ensure-esbuild-binary.mjs
@@ -1,0 +1,39 @@
+import { access } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const binaryName = process.platform === 'win32' ? 'esbuild.exe' : 'esbuild';
+const projectRoot = process.cwd();
+const binaryPath = path.join(projectRoot, 'node_modules', 'esbuild', 'bin', binaryName);
+const installScriptPath = path.join(projectRoot, 'node_modules', 'esbuild', 'install.js');
+
+async function ensureBinary() {
+  try {
+    await access(binaryPath, fsConstants.X_OK);
+    return;
+  } catch (binaryMissingError) {
+    // Continue to attempt re-installation.
+  }
+
+  try {
+    await access(installScriptPath, fsConstants.R_OK);
+  } catch (missingInstallScriptError) {
+    throw new Error('esbuild install script is missing. Please reinstall the `esbuild` package.');
+  }
+
+  const result = spawnSync(process.execPath, [installScriptPath], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`esbuild install script exited with code ${result.status}.`);
+  }
+}
+
+await ensureBinary();


### PR DESCRIPTION
## Summary
- add a postinstall script that re-runs esbuild's installer when its binary is missing
- wire the postinstall script into package.json so Codespaces installs the correct esbuild binary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de78e148cc8332b28dc7621de8c64a