### PR TITLE
Fix esbuild binary resolution for Vite commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "node ./scripts/run-with-esbuild-binary.mjs vite",
+    "build": "tsc -b && node ./scripts/run-with-esbuild-binary.mjs vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
+    "preview": "node ./scripts/run-with-esbuild-binary.mjs vite preview",
     "postinstall": "node ./scripts/ensure-esbuild-binary.mjs"
   },
   "dependencies": {

--- a/scripts/run-with-esbuild-binary.mjs
+++ b/scripts/run-with-esbuild-binary.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+
+import './ensure-esbuild-binary.mjs';
+
+const [, , command, ...args] = process.argv;
+
+if (!command) {
+  console.error('Usage: node run-with-esbuild-binary.mjs <command> [..args]');
+  process.exit(1);
+}
+
+const binaryName = process.platform === 'win32' ? 'esbuild.exe' : 'esbuild';
+const binaryPath = path.join(process.cwd(), 'node_modules', 'esbuild', 'bin', binaryName);
+
+const child = spawn(command, args, {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    ESBUILD_BINARY_PATH: binaryPath,
+  },
+  shell: process.platform === 'win32',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a helper script that sets ESBUILD_BINARY_PATH before spawning commands
- update Vite-related npm scripts to run through the helper so the bundled binary is always used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7b6038ec833297e8e0002bc258f3