### PR TITLE
Add SM2-lite vocab scheduling and review tray

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { FeedbackChip } from './components';
+import { FeedbackChip, ReviewTray } from './components';
 import { selectCurrentNode, useGameState } from './game/state';
 import type { PlayerChoice } from './scenes/types';
 
@@ -30,23 +30,30 @@ type MicroReviewData = {
   choices: PlayerChoice[];
 };
 
-type Attempt = {
+type VocabItemSchedule = {
   itemId: string;
-  itemLabel: string;
-  evaluation: PlayerChoice['eval'];
-  confidence: ConfidenceLevel;
-  quality: number;
-  timestamp: number;
-  sourceNodeId: string;
-  isMicroReview: boolean;
+  label: string;
+  ease: number;
+  interval: number;
+  repetitions: number;
+  nextDue: number;
+  lastReviewed: number | null;
+  reviewCount: number;
+  totalQuality: number;
 };
 
-type WeakItem = {
+type ReviewCandidate = {
   itemId: string;
-  itemLabel: string;
-  averageQuality: number;
-  attempts: number;
+  label: string;
+  ease: number;
+  nextDue: number;
+  isDue: boolean;
+  averageQuality: number | null;
+  rating?: number;
 };
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const SM2_MIN_EASE = 1.3;
 
 const ConfidenceButtons = ({ onSelect }: { onSelect: (level: ConfidenceLevel) => void }) => (
   <div className="flex w-full justify-between gap-2">
@@ -89,7 +96,73 @@ function App() {
   const [pendingMicroReview, setPendingMicroReview] = useState<MicroReviewData | null>(null);
   const [activeMicroReview, setActiveMicroReview] = useState<MicroReviewData | null>(null);
   const [postMicroReviewChoice, setPostMicroReviewChoice] = useState<PlayerChoice | null>(null);
-  const [attempts, setAttempts] = useState<Attempt[]>([]);
+  const [vocabSchedule, setVocabSchedule] = useState<Record<string, VocabItemSchedule>>({});
+  const [reviewRatings, setReviewRatings] = useState<Record<string, number>>({});
+
+  const applySchedulingUpdates = useCallback(
+    (updates: { itemId: string; label: string; quality: number }[]) => {
+      if (updates.length === 0) {
+        return;
+      }
+
+      const timestamp = Date.now();
+
+      setVocabSchedule((previous) => {
+        const next = { ...previous };
+
+        for (const update of updates) {
+          const quality = Math.max(0, Math.min(5, update.quality));
+          const existing = next[update.itemId] ?? {
+            itemId: update.itemId,
+            label: update.label,
+            ease: 2.5,
+            interval: 0,
+            repetitions: 0,
+            nextDue: timestamp,
+            lastReviewed: null,
+            reviewCount: 0,
+            totalQuality: 0,
+          };
+
+          let ease = existing.ease - 0.8 + 0.28 * quality - 0.02 * quality * quality;
+          ease = Number.isFinite(ease) ? Math.max(SM2_MIN_EASE, ease) : existing.ease;
+
+          let repetitions = existing.repetitions;
+          let interval = existing.interval;
+
+          if (quality < 3) {
+            repetitions = 0;
+            interval = 1;
+          } else {
+            repetitions += 1;
+
+            if (repetitions === 1) {
+              interval = 1;
+            } else if (repetitions === 2) {
+              interval = 6;
+            } else {
+              interval = Math.max(1, Math.round(existing.interval * ease));
+            }
+          }
+
+          next[update.itemId] = {
+            ...existing,
+            label: update.label ?? existing.label,
+            ease,
+            repetitions,
+            interval,
+            nextDue: timestamp + interval * DAY_IN_MS,
+            lastReviewed: timestamp,
+            reviewCount: existing.reviewCount + 1,
+            totalQuality: existing.totalQuality + quality,
+          };
+        }
+
+        return next;
+      });
+    },
+    [],
+  );
 
   const clearAdvanceTimeout = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -244,19 +317,25 @@ function App() {
       setPendingConfidence(null);
 
       const quality = computeQuality(choice.eval, level);
-      setAttempts((prev) => [
-        ...prev,
-        {
-          itemId: choice.id,
-          itemLabel: choice.text,
-          evaluation: choice.eval,
-          confidence: level,
+
+      const isCorrect = choice.eval === 'good' || choice.eval === 'ok';
+      if (isCorrect && choice.wordsLearned && choice.wordsLearned.length > 0) {
+        const schedulingUpdates = choice.wordsLearned.map((word) => ({
+          itemId: word,
+          label: word,
           quality,
-          timestamp: Date.now(),
-          sourceNodeId: contextNodeId,
-          isMicroReview,
-        },
-      ]);
+        }));
+
+        applySchedulingUpdates(schedulingUpdates);
+
+        setReviewRatings((prev) => {
+          const next = { ...prev };
+          for (const word of choice.wordsLearned ?? []) {
+            delete next[word];
+          }
+          return next;
+        });
+      }
 
       if (isMicroReview) {
         if (!activeMicroReview) {
@@ -290,63 +369,106 @@ function App() {
 
       scheduleAdvance(choice);
     },
-    [activeMicroReview, computeQuality, maybeScheduleMicroReview, pendingConfidence, pendingMicroReview, postMicroReviewChoice, scheduleAdvance],
+    [
+      activeMicroReview,
+      applySchedulingUpdates,
+      computeQuality,
+      maybeScheduleMicroReview,
+      pendingConfidence,
+      pendingMicroReview,
+      postMicroReviewChoice,
+      scheduleAdvance,
+    ],
   );
 
   const handleStartScene = useCallback(() => {
-    setAttempts([]);
     setFeedbackByChoice({});
     setMicroReviewFeedback({});
     setPendingConfidence(null);
     setPendingMicroReview(null);
     setActiveMicroReview(null);
     setPostMicroReviewChoice(null);
+    setReviewRatings({});
     startScene(CAFE_SCENE_ID);
   }, [startScene]);
 
   const handleReset = useCallback(() => {
     clearAdvanceTimeout();
-    setAttempts([]);
     setFeedbackByChoice({});
     setMicroReviewFeedback({});
     setPendingConfidence(null);
     setPendingMicroReview(null);
     setActiveMicroReview(null);
     setPostMicroReviewChoice(null);
+    setReviewRatings({});
     reset();
   }, [clearAdvanceTimeout, reset]);
 
-  const weakestItems: WeakItem[] = useMemo(() => {
-    if (attempts.length === 0) {
+  const reviewTrayItems: ReviewCandidate[] = useMemo(() => {
+    const entries = Object.values(vocabSchedule);
+    if (entries.length === 0) {
       return [];
     }
 
-    const aggregated = new Map<string, { totalQuality: number; attempts: number; itemLabel: string }>();
+    const now = Date.now();
 
-    for (const attempt of attempts) {
-      const existing = aggregated.get(attempt.itemId) ?? {
-        totalQuality: 0,
-        attempts: 0,
-        itemLabel: attempt.itemLabel,
-      };
+    const sorted = [...entries].sort((a, b) => {
+      const aDue = a.nextDue <= now;
+      const bDue = b.nextDue <= now;
 
-      existing.totalQuality += attempt.quality;
-      existing.attempts += 1;
-      existing.itemLabel = attempt.itemLabel;
+      if (aDue && !bDue) {
+        return -1;
+      }
 
-      aggregated.set(attempt.itemId, existing);
-    }
+      if (!aDue && bDue) {
+        return 1;
+      }
 
-    return Array.from(aggregated.entries())
-      .map(([itemId, value]) => ({
-        itemId,
-        itemLabel: value.itemLabel,
-        averageQuality: value.totalQuality / value.attempts,
-        attempts: value.attempts,
-      }))
-      .sort((a, b) => a.averageQuality - b.averageQuality)
-      .slice(0, 3);
-  }, [attempts]);
+      if (aDue && bDue) {
+        return a.nextDue - b.nextDue;
+      }
+
+      const aAverage = a.reviewCount > 0 ? a.totalQuality / a.reviewCount : Number.POSITIVE_INFINITY;
+      const bAverage = b.reviewCount > 0 ? b.totalQuality / b.reviewCount : Number.POSITIVE_INFINITY;
+
+      if (aAverage !== bAverage) {
+        return aAverage - bAverage;
+      }
+
+      if (a.ease !== b.ease) {
+        return a.ease - b.ease;
+      }
+
+      return a.nextDue - b.nextDue;
+    });
+
+    return sorted.slice(0, 3).map((item) => ({
+      itemId: item.itemId,
+      label: item.label,
+      ease: item.ease,
+      nextDue: item.nextDue,
+      isDue: item.nextDue <= now,
+      averageQuality: item.reviewCount > 0 ? item.totalQuality / item.reviewCount : null,
+      rating: reviewRatings[item.itemId],
+    }));
+  }, [reviewRatings, vocabSchedule]);
+
+  const handleReviewRate = useCallback(
+    (itemId: string, quality: number) => {
+      const scheduleEntry = vocabSchedule[itemId];
+      if (!scheduleEntry) {
+        return;
+      }
+
+      applySchedulingUpdates([{ itemId, label: scheduleEntry.label, quality }]);
+
+      setReviewRatings((prev) => ({
+        ...prev,
+        [itemId]: Math.max(0, Math.min(5, quality)),
+      }));
+    },
+    [applySchedulingUpdates, vocabSchedule],
+  );
 
   return (
     <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center bg-gradient-to-b from-emerald-50 via-white to-emerald-100 px-6 py-16 text-slate-900">
@@ -464,22 +586,11 @@ function App() {
                           כל הכבוד! סיימת את השיחה.
                         </p>
                         <div className="w-full rounded-xl bg-white/70 p-4 text-left">
-                          <h3 className="text-base font-semibold text-emerald-700">Focus on these next</h3>
-                          {weakestItems.length > 0 ? (
-                            <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-slate-700">
-                              {weakestItems.map((item) => (
-                                <li key={item.itemId}>
-                                  <div className="flex items-center justify-between gap-4">
-                                    <span dir="rtl" lang="he">{item.itemLabel}</span>
-                                    <span className="text-xs font-semibold text-slate-500">
-                                      {item.averageQuality.toFixed(1)} / 5 · {item.attempts} try{item.attempts === 1 ? '' : 's'}
-                                    </span>
-                                  </div>
-                                </li>
-                              ))}
-                            </ol>
+                          <h3 className="text-base font-semibold text-emerald-700">Review tray</h3>
+                          {reviewTrayItems.length > 0 ? (
+                            <ReviewTray items={reviewTrayItems} onRate={handleReviewRate} />
                           ) : (
-                            <p className="mt-3 text-sm text-slate-600">No weaknesses detected yet—great job!</p>
+                            <p className="mt-3 text-sm text-slate-600">No review items yet—keep exploring!</p>
                           )}
                         </div>
                         <button

--- a/src/components/ReviewTray.tsx
+++ b/src/components/ReviewTray.tsx
@@ -1,0 +1,105 @@
+import type { FC } from 'react';
+
+type ReviewTrayItem = {
+  itemId: string;
+  label: string;
+  ease: number;
+  nextDue: number;
+  isDue: boolean;
+  averageQuality: number | null;
+  rating?: number;
+};
+
+type ReviewTrayProps = {
+  items: ReviewTrayItem[];
+  onRate: (itemId: string, quality: number) => void;
+};
+
+const reviewOptions: { label: string; quality: number; description: string }[] = [
+  { label: 'Forgot', quality: 2, description: "I couldn't recall it." },
+  { label: 'Hesitant', quality: 3, description: 'Needed a moment to remember.' },
+  { label: 'Good', quality: 4, description: 'Remembered with light effort.' },
+  { label: 'Easy', quality: 5, description: 'Instant recall.' },
+];
+
+const formatRelativeTime = (target: number): string => {
+  const now = Date.now();
+  const diffMs = target - now;
+  const absMs = Math.abs(diffMs);
+
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (absMs < minute) {
+    return 'now';
+  }
+
+  if (absMs < hour) {
+    const minutes = Math.round(absMs / minute);
+    return diffMs >= 0 ? `in ${minutes} minute${minutes === 1 ? '' : 's'}` : `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  }
+
+  if (absMs < day) {
+    const hours = Math.round(absMs / hour);
+    return diffMs >= 0 ? `in ${hours} hour${hours === 1 ? '' : 's'}` : `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  }
+
+  const days = Math.round(absMs / day);
+  return diffMs >= 0 ? `in ${days} day${days === 1 ? '' : 's'}` : `${days} day${days === 1 ? '' : 's'} ago`;
+};
+
+export const ReviewTray: FC<ReviewTrayProps> = ({ items, onRate }) => (
+  <ul className="mt-3 space-y-3">
+    {items.map((item) => {
+      const hasRating = typeof item.rating === 'number';
+      const statusLabel = item.isDue ? 'Due now' : formatRelativeTime(item.nextDue);
+      const averageQuality = item.averageQuality ?? undefined;
+
+      return (
+        <li
+          key={item.itemId}
+          className="rounded-xl border border-emerald-100 bg-white/80 p-4 shadow-sm"
+        >
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <span dir="rtl" lang="he" className="text-lg font-semibold text-emerald-800">
+                {item.label}
+              </span>
+              <span className={`text-xs font-semibold ${item.isDue ? 'text-rose-600' : 'text-slate-500'}`}>
+                {statusLabel}
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-3 text-xs text-slate-500">
+              <span>Ease {item.ease.toFixed(2)}</span>
+              {averageQuality !== undefined && (
+                <span>
+                  Avg quality {averageQuality.toFixed(1)}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {reviewOptions.map((option) => (
+                <button
+                  key={option.quality}
+                  type="button"
+                  onClick={() => onRate(item.itemId, option.quality)}
+                  className="flex-1 min-w-[120px] rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-semibold text-emerald-800 shadow-sm transition hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                  title={option.description}
+                  disabled={hasRating}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            {hasRating && (
+              <p className="text-xs font-medium text-emerald-600">
+                Next review {formatRelativeTime(item.nextDue)}
+              </p>
+            )}
+          </div>
+        </li>
+      );
+    })}
+  </ul>
+);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as FeedbackChip } from './FeedbackChip';
+export { ReviewTray } from './ReviewTray';


### PR DESCRIPTION
## Summary
- implement SM2-lite scheduling that updates ease and due dates for vocabulary items on correct answers
- add an end-of-scene ReviewTray that surfaces due or weak items and lets players grade their recall

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7ceb0190833292e970a45a1f79ed