### PR TITLE
Add player profile and adaptive hints for gendered choices

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,40 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { FeedbackChip, ReviewTray } from './components';
 import { selectCurrentNode, useGameState } from './game/state';
-import type { PlayerChoice } from './scenes/types';
+import type { GenderPresentation, PlayerChoice, PlayerLevel } from './scenes/types';
 
 const CAFE_SCENE_ID = 'cafe';
+
+const GENDER_OPTIONS: { value: GenderPresentation; label: string; description: string }[] = [
+  {
+    value: 'masculine',
+    label: 'Masculine',
+    description: 'Use masculine verb endings in your replies.',
+  },
+  {
+    value: 'feminine',
+    label: 'Feminine',
+    description: 'Use feminine verb endings in your replies.',
+  },
+  {
+    value: 'neutral',
+    label: 'Neutral',
+    description: 'Prefer mixed or gender-neutral phrasing.',
+  },
+];
+
+const LEVEL_OPTIONS: { value: PlayerLevel; label: string; description: string }[] = [
+  {
+    value: 'beginner',
+    label: 'Beginner',
+    description: 'Show transliteration hints by default.',
+  },
+  {
+    value: 'advanced',
+    label: 'Advanced',
+    description: 'Hide hints unless a concept trips you up.',
+  },
+];
 
 type ChoiceFeedback = Record<
   string,
@@ -87,6 +118,8 @@ function App() {
   const currentNode = useGameState(selectCurrentNode);
   const goToNode = useGameState((state) => state.goToNode);
   const reset = useGameState((state) => state.reset);
+  const profile = useGameState((state) => state.profile);
+  const updateProfile = useGameState((state) => state.updateProfile);
 
   const hasStarted = Boolean(sceneId);
   const [feedbackByChoice, setFeedbackByChoice] = useState<ChoiceFeedback>({});
@@ -98,6 +131,68 @@ function App() {
   const [postMicroReviewChoice, setPostMicroReviewChoice] = useState<PlayerChoice | null>(null);
   const [vocabSchedule, setVocabSchedule] = useState<Record<string, VocabItemSchedule>>({});
   const [reviewRatings, setReviewRatings] = useState<Record<string, number>>({});
+  const [missedConcepts, setMissedConcepts] = useState<Record<string, boolean>>({});
+
+  const resolveChoiceForProfile = useCallback(
+    (choice: PlayerChoice): PlayerChoice => {
+      const variant =
+        choice.variants?.[profile.genderPresentation] ?? choice.variants?.neutral;
+
+      if (!variant) {
+        return choice;
+      }
+
+      return {
+        ...choice,
+        text: variant.text ?? choice.text,
+        transliteration: variant.transliteration ?? choice.transliteration,
+        eval: variant.eval ?? choice.eval,
+        feedback: variant.feedback ?? choice.feedback,
+      };
+    },
+    [profile.genderPresentation],
+  );
+
+  const handleGenderChange = useCallback(
+    (value: GenderPresentation) => {
+      if (value === profile.genderPresentation) {
+        return;
+      }
+
+      updateProfile({ genderPresentation: value });
+    },
+    [profile.genderPresentation, updateProfile],
+  );
+
+  const handleLevelChange = useCallback(
+    (value: PlayerLevel) => {
+      if (value === profile.level) {
+        return;
+      }
+
+      updateProfile({ level: value });
+    },
+    [profile.level, updateProfile],
+  );
+
+  const shouldShowTransliteration = useCallback(
+    (choice: PlayerChoice) => {
+      if (!choice.transliteration) {
+        return false;
+      }
+
+      if (profile.level === 'beginner') {
+        return true;
+      }
+
+      if (!choice.conceptId) {
+        return false;
+      }
+
+      return Boolean(missedConcepts[choice.conceptId]);
+    },
+    [missedConcepts, profile.level],
+  );
 
   const applySchedulingUpdates = useCallback(
     (updates: { itemId: string; label: string; quality: number }[]) => {
@@ -259,6 +354,13 @@ function App() {
         }));
       }
 
+      if (choice.conceptId && choice.eval === 'wrong') {
+        setMissedConcepts((prev) => ({
+          ...prev,
+          [choice.conceptId ?? '']: true,
+        }));
+      }
+
       if (choice.eval === 'good') {
         speak(choice.text);
       }
@@ -389,6 +491,7 @@ function App() {
     setActiveMicroReview(null);
     setPostMicroReviewChoice(null);
     setReviewRatings({});
+    setMissedConcepts({});
     startScene(CAFE_SCENE_ID);
   }, [startScene]);
 
@@ -401,6 +504,7 @@ function App() {
     setActiveMicroReview(null);
     setPostMicroReviewChoice(null);
     setReviewRatings({});
+    setMissedConcepts({});
     reset();
   }, [clearAdvanceTimeout, reset]);
 
@@ -482,6 +586,65 @@ function App() {
       </header>
 
       <main className="mt-12 w-full flex-1">
+        <section className="mb-8 rounded-2xl bg-white/80 p-6 shadow-lg">
+          <h2 className="text-lg font-semibold text-emerald-700">Player profile</h2>
+          <p className="mt-1 text-sm text-slate-600">
+            Tune the conversation so your responses and hints match your goals.
+          </p>
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-500">
+                Gender presentation
+              </h3>
+              <div className="flex flex-col gap-3">
+                {GENDER_OPTIONS.map((option) => {
+                  const isActive = profile.genderPresentation === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => handleGenderChange(option.value)}
+                      aria-pressed={isActive}
+                      className={`rounded-xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 ${
+                        isActive
+                          ? 'border-emerald-500 bg-emerald-50 text-emerald-800 shadow'
+                          : 'border-slate-200 bg-white/70 text-slate-700 hover:border-emerald-300'
+                      }`}
+                    >
+                      <span className="font-semibold">{option.label}</span>
+                      <span className="mt-1 block text-sm text-slate-500">{option.description}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-500">Learning mode</h3>
+              <div className="flex flex-col gap-3">
+                {LEVEL_OPTIONS.map((option) => {
+                  const isActive = profile.level === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => handleLevelChange(option.value)}
+                      aria-pressed={isActive}
+                      className={`rounded-xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 ${
+                        isActive
+                          ? 'border-emerald-500 bg-emerald-50 text-emerald-800 shadow'
+                          : 'border-slate-200 bg-white/70 text-slate-700 hover:border-emerald-300'
+                      }`}
+                    >
+                      <span className="font-semibold">{option.label}</span>
+                      <span className="mt-1 block text-sm text-slate-500">{option.description}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
         {!hasStarted && (
           <div className="flex flex-col items-center gap-6">
             <p className="text-center text-lg text-slate-600">
@@ -510,35 +673,42 @@ function App() {
                     </p>
                   </div>
 
-                  <ul className="flex flex-col gap-4">
-                    {activeMicroReview.choices.map((choice) => {
-                      const feedback = microReviewFeedback[choice.id];
-                      const awaitingConfidence = pendingConfidence?.choice.id === choice.id;
-                      return (
-                        <li key={choice.id} className="flex w-full flex-col items-end gap-2">
-                          <button
-                            type="button"
-                            onClick={() => handleChoiceClick(choice)}
-                            className="w-full rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-right text-lg font-semibold text-emerald-800 shadow-sm transition hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-                            dir="rtl"
-                            lang="he"
-                            disabled={Boolean(pendingConfidence) && !awaitingConfidence}
-                          >
-                            {choice.text}
-                          </button>
-                          {feedback && (
-                            <FeedbackChip evaluation={feedback.evaluation} message={feedback.message} />
-                          )}
-                          {awaitingConfidence && (
-                            <div className="w-full text-left">
-                              <p className="mb-2 text-sm font-medium text-slate-600">How confident did you feel?</p>
-                              <ConfidenceButtons onSelect={handleConfidenceSelect} />
-                            </div>
-                          )}
-                        </li>
-                      );
-                    })}
-                  </ul>
+                    <ul className="flex flex-col gap-4">
+                      {activeMicroReview.choices.map((choice) => {
+                        const resolvedChoice = resolveChoiceForProfile(choice);
+                        const feedback = microReviewFeedback[resolvedChoice.id];
+                        const awaitingConfidence = pendingConfidence?.choice.id === resolvedChoice.id;
+                        const showTransliteration = shouldShowTransliteration(resolvedChoice);
+                        return (
+                          <li key={resolvedChoice.id} className="flex w-full flex-col items-end gap-2">
+                            <button
+                              type="button"
+                              onClick={() => handleChoiceClick(resolvedChoice)}
+                              className="w-full rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-right text-lg font-semibold text-emerald-800 shadow-sm transition hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                              dir="rtl"
+                              lang="he"
+                              disabled={Boolean(pendingConfidence) && !awaitingConfidence}
+                            >
+                              {resolvedChoice.text}
+                            </button>
+                            {showTransliteration && resolvedChoice.transliteration && (
+                              <span className="self-end text-sm font-medium text-slate-500" dir="ltr" lang="en">
+                                {resolvedChoice.transliteration}
+                              </span>
+                            )}
+                            {feedback && (
+                              <FeedbackChip evaluation={feedback.evaluation} message={feedback.message} />
+                            )}
+                            {awaitingConfidence && (
+                              <div className="w-full text-left">
+                                <p className="mb-2 text-sm font-medium text-slate-600">How confident did you feel?</p>
+                                <ConfidenceButtons onSelect={handleConfidenceSelect} />
+                              </div>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
                 </>
               ) : (
                 currentNode && (
@@ -550,36 +720,43 @@ function App() {
                       </p>
                     </div>
 
-                    {currentNode.playerChoices.length > 0 ? (
-                      <ul className="flex flex-col gap-4">
-                        {currentNode.playerChoices.map((choice) => {
-                          const feedback = feedbackByChoice[choice.id];
-                          const awaitingConfidence = pendingConfidence?.choice.id === choice.id;
-                          return (
-                            <li key={choice.id} className="flex flex-col items-end gap-2">
-                              <button
-                                type="button"
-                                onClick={() => handleChoiceClick(choice)}
-                                className="w-full rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-right text-lg font-semibold text-emerald-800 shadow-sm transition hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-                                dir="rtl"
-                                lang="he"
-                                disabled={Boolean(pendingConfidence) && !awaitingConfidence}
-                              >
-                                {choice.text}
-                              </button>
-                              {feedback && (
-                                <FeedbackChip evaluation={feedback.evaluation} message={feedback.message} />
-                              )}
-                              {awaitingConfidence && (
-                                <div className="w-full text-left">
-                                  <p className="mb-2 text-sm font-medium text-slate-600">How confident did you feel?</p>
-                                  <ConfidenceButtons onSelect={handleConfidenceSelect} />
-                                </div>
-                              )}
-                            </li>
-                          );
-                        })}
-                      </ul>
+                      {currentNode.playerChoices.length > 0 ? (
+                        <ul className="flex flex-col gap-4">
+                          {currentNode.playerChoices.map((choice) => {
+                            const resolvedChoice = resolveChoiceForProfile(choice);
+                            const feedback = feedbackByChoice[resolvedChoice.id];
+                            const awaitingConfidence = pendingConfidence?.choice.id === resolvedChoice.id;
+                            const showTransliteration = shouldShowTransliteration(resolvedChoice);
+                            return (
+                              <li key={resolvedChoice.id} className="flex flex-col items-end gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => handleChoiceClick(resolvedChoice)}
+                                  className="w-full rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-right text-lg font-semibold text-emerald-800 shadow-sm transition hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                                  dir="rtl"
+                                  lang="he"
+                                  disabled={Boolean(pendingConfidence) && !awaitingConfidence}
+                                >
+                                  {resolvedChoice.text}
+                                </button>
+                                {showTransliteration && resolvedChoice.transliteration && (
+                                  <span className="self-end text-sm font-medium text-slate-500" dir="ltr" lang="en">
+                                    {resolvedChoice.transliteration}
+                                  </span>
+                                )}
+                                {feedback && (
+                                  <FeedbackChip evaluation={feedback.evaluation} message={feedback.message} />
+                                )}
+                                {awaitingConfidence && (
+                                  <div className="w-full text-left">
+                                    <p className="mb-2 text-sm font-medium text-slate-600">How confident did you feel?</p>
+                                    <ConfidenceButtons onSelect={handleConfidenceSelect} />
+                                  </div>
+                                )}
+                              </li>
+                            );
+                          })}
+                        </ul>
                     ) : (
                       <div className="flex flex-col items-center gap-6 rounded-xl bg-emerald-50 p-6 text-center">
                         <p className="text-lg font-semibold text-emerald-700" dir="rtl" lang="he">

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 
-import type { Scene, SceneNode } from '../scenes/types';
+import type {
+  GenderPresentation,
+  PlayerLevel,
+  Scene,
+  SceneNode,
+} from '../scenes/types';
 import cafeScene from '../scenes/cafe.json';
 
 const cafe = cafeScene as Scene;
@@ -9,15 +14,22 @@ const scenes: Record<string, Scene> = {
   [cafe.id]: cafe,
 };
 
+type PlayerProfile = {
+  genderPresentation: GenderPresentation;
+  level: PlayerLevel;
+};
+
 type GameState = {
   sceneId: string | null;
   nodeId: string | null;
   points: number;
   wordsLearned: string[];
   scenes: Record<string, Scene>;
+  profile: PlayerProfile;
   startScene: (sceneId: string) => void;
   goToNode: (nextNodeId: string, reward?: number, wordsLearned?: string[]) => void;
   reset: () => void;
+  updateProfile: (updates: Partial<PlayerProfile>) => void;
 };
 
 export const useGameState = create<GameState>((set) => ({
@@ -26,6 +38,10 @@ export const useGameState = create<GameState>((set) => ({
   points: 0,
   wordsLearned: [],
   scenes,
+  profile: {
+    genderPresentation: 'feminine',
+    level: 'beginner',
+  },
   startScene: (sceneId) => {
     const scene = scenes[sceneId];
     if (!scene) {
@@ -71,6 +87,10 @@ export const useGameState = create<GameState>((set) => ({
       points: 0,
       wordsLearned: [],
     }),
+  updateProfile: (updates) =>
+    set((state) => ({
+      profile: { ...state.profile, ...updates },
+    })),
 }));
 
 export const selectCurrentScene = (state: GameState): Scene | null => {

--- a/src/scenes/cafe.json
+++ b/src/scenes/cafe.json
@@ -14,20 +14,34 @@
         {
           "id": "order-cappuccino",
           "text": "אני רוצה קפה הפוך, בבקשה.",
+          "transliteration": "ani rotze kafe hafuch, bevakasha.",
+          "conceptId": "cafe-order",
           "nextNodeId": "drink-details",
           "eval": "good",
           "feedback": "מעולה! זו הדרך המדויקת לבקש קפה הפוך.",
           "reward": 2,
-          "wordsLearned": ["קפה הפוך"]
+          "wordsLearned": ["קפה הפוך"],
+          "variants": {
+            "feminine": {
+              "transliteration": "ani rotzah kafe hafuch, bevakasha."
+            }
+          }
         },
         {
           "id": "order-coffee",
           "text": "אפשר קפה, תודה.",
+          "transliteration": "efshar kafe, toda.",
+          "conceptId": "cafe-order",
           "nextNodeId": "drink-details",
           "eval": "ok",
           "feedback": "סבבה! אפשר לבקש גם יותר ספציפי אם תרצה.",
           "reward": 1,
-          "wordsLearned": ["קפה"]
+          "wordsLearned": ["קפה"],
+          "variants": {
+            "feminine": {
+              "transliteration": "efshar kafe, toda."
+            }
+          }
         },
         {
           "id": "ask-restroom",
@@ -48,7 +62,9 @@
         {
           "id": "details-brown-sugar",
           "text": "אפשר מעט סוכר חום.",
-          "nextNodeId": "closing",
+          "transliteration": "efshar me'at sukar chum.",
+          "conceptId": "sweetener-choice",
+          "nextNodeId": "newcomer",
           "eval": "good",
           "feedback": "בחירה מצוינת! כך תבקש סוכר חום.",
           "reward": 2,
@@ -57,7 +73,9 @@
         {
           "id": "details-no-sugar",
           "text": "בלי סוכר, תודה.",
-          "nextNodeId": "closing",
+          "transliteration": "bli sukar, toda.",
+          "conceptId": "sweetener-choice",
+          "nextNodeId": "newcomer",
           "eval": "ok",
           "feedback": "אין בעיה! זו תשובה ברורה ומנומסת.",
           "reward": 1
@@ -68,6 +86,82 @@
           "nextNodeId": "drink-details",
           "eval": "wrong",
           "feedback": "נחמד, אבל הבריסטה עדיין מחכה לתשובה לגבי הקפה."
+        }
+      ]
+    },
+    "newcomer": {
+      "id": "newcomer",
+      "npc": {
+        "speaker": "הבריסטה",
+        "text": "נהדר. פעם ראשונה שלך כאן?"
+      },
+      "playerChoices": [
+        {
+          "id": "newcomer-masc",
+          "text": "אני חדש כאן.",
+          "transliteration": "ani chadash kan.",
+          "conceptId": "newcomer-status",
+          "nextNodeId": "closing",
+          "eval": "wrong",
+          "feedback": "הצורה הזאת מתאימה לדובר בלשון זכר.",
+          "reward": 2,
+          "wordsLearned": ["חדש"],
+          "variants": {
+            "masculine": {
+              "eval": "good",
+              "feedback": "בדיוק כך! זו צורת הזכר המתאימה."
+            },
+            "neutral": {
+              "eval": "ok",
+              "feedback": "זו צורת זכר; אפשר לבחור גם ניסוח ניטרלי."
+            }
+          }
+        },
+        {
+          "id": "newcomer-fem",
+          "text": "אני חדשה כאן.",
+          "transliteration": "ani chadasha kan.",
+          "conceptId": "newcomer-status",
+          "nextNodeId": "closing",
+          "eval": "wrong",
+          "feedback": "זו צורת נקבה — בחרי בה אם את מציגה בלשון נקבה.",
+          "reward": 2,
+          "wordsLearned": ["חדשה"],
+          "variants": {
+            "feminine": {
+              "eval": "good",
+              "feedback": "מעולה! זו הצורה המתאימה לנקבה."
+            },
+            "neutral": {
+              "eval": "ok",
+              "feedback": "זו צורת נקבה; אפשר גם ניסוח ניטרלי."
+            }
+          }
+        },
+        {
+          "id": "newcomer-neutral",
+          "text": "אני פה פעם ראשונה.",
+          "transliteration": "ani po pa'am rishona.",
+          "conceptId": "newcomer-status",
+          "nextNodeId": "closing",
+          "eval": "ok",
+          "feedback": "זה ניסוח ניטרלי שמתאים לכולם.",
+          "reward": 1,
+          "wordsLearned": ["פעם ראשונה"],
+          "variants": {
+            "neutral": {
+              "eval": "good",
+              "feedback": "בול! זה ניסוח ניטרלי שמתאים להעדפה שלך."
+            },
+            "masculine": {
+              "eval": "ok",
+              "feedback": "נכון, אך תוכל גם לומר \"אני חדש\" לצורת זכר."
+            },
+            "feminine": {
+              "eval": "ok",
+              "feedback": "נכון, אך תוכלי גם לומר \"אני חדשה\" לצורת נקבה."
+            }
+          }
         }
       ]
     },

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -3,14 +3,30 @@ export type DialogueLine = {
   text: string;
 };
 
+export type GenderPresentation = 'masculine' | 'feminine' | 'neutral';
+
+export type PlayerLevel = 'beginner' | 'advanced';
+
+export type ChoiceVariant = {
+  text?: string;
+  transliteration?: string;
+  eval?: 'good' | 'ok' | 'wrong';
+  feedback?: string;
+};
+
 export type PlayerChoice = {
   id: string;
   text: string;
+  transliteration?: string;
+  conceptId?: string;
   nextNodeId: string;
   eval: 'good' | 'ok' | 'wrong';
   feedback: string;
   reward?: number;
   wordsLearned?: string[];
+  variants?: Partial<Record<GenderPresentation, ChoiceVariant>> & {
+    neutral?: ChoiceVariant;
+  };
 };
 
 export type SceneNode = {


### PR DESCRIPTION
## Summary
- add player profile state with gender presentation and learning level selectors
- resolve dialogue choices against the active profile to drive evaluation, feedback, and transliteration hints
- enrich the café scene with transliterations and a newcomer exchange that adapts to gendered verb forms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7fcee6248332958b806bbf78c26a